### PR TITLE
Correção de loop "infinito" ao adicionar produto no carrinho

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** shipping, delivery, woocommerce, enviofacil, envio fácil<br/>
 **Requires at least:** 4.6<br/>
 **Tested up to:** 5.0<br/>
-**Stable tag:** 0.1.5<br/>
+**Stable tag:** 0.1.6<br/>
 **Requires PHP:** 5.6<br/>
 **License:** GPLv2 or later<br/>
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html<br/>

--- a/includes/class-woo-enviofacil-shipping.php
+++ b/includes/class-woo-enviofacil-shipping.php
@@ -128,7 +128,9 @@ class WOO_EnvioFacil_Shipping extends WC_Shipping_Method {
 	 * @see WOO_Shipping_Method::calculate_shipping()
 	 */
 	public function calculate_shipping( $package = array() ) {
-		if ( $this->_origin_postcode === '00000-000' || $this->_origin_postcode === '' ) {
+		if ( $this->_origin_postcode === '00000-000'
+			|| $this->_origin_postcode === ''
+			|| $package['destination']['postcode'] === '') {
 			return;
 		}
 

--- a/includes/class-woo-enviofacil-shipping.php
+++ b/includes/class-woo-enviofacil-shipping.php
@@ -129,8 +129,8 @@ class WOO_EnvioFacil_Shipping extends WC_Shipping_Method {
 	 */
 	public function calculate_shipping( $package = array() ) {
 		if ( $this->_origin_postcode === '00000-000'
-			|| $this->_origin_postcode === ''
-			|| $package['destination']['postcode'] === '') {
+		  || $this->_origin_postcode === ''
+		  || $package['destination']['postcode'] === '') {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: moacirbrg
 Tags: shipping, delivery, woocommerce, enviofacil, envio fácil
 Requires at least: 4.6
 Tested up to: 5.0
-Stable tag: 0.1.5
+Stable tag: 0.1.6
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/woo-enviofacil.php
+++ b/woo-enviofacil.php
@@ -4,7 +4,7 @@
  * Plugin URI:           https://github.com/moacirbrg/woo-enviofacil
  * Description:          Adds Envio Fácil shipping methods to WooCommerce
  * Author:               Moacir Braga
- * Version:              0.1.5
+ * Version:              0.1.6
  * License:              GPLv2 or later
  * Text Domain:          woo-enviofacil
  * Domain Path:          /languages


### PR DESCRIPTION
## Correção de loop "infinito" ao adicionar produto no carrinho

### Descrição

Ao adicionar um produto no carrinho, é chamado a função **calculate_shipping**, sendo que nessa etapa o usuário ainda não informou seu endereço/CEP, gerando um loop de 2 minutos até liberar o produto no carrinho.

Acredito que esse comportamento tenha sido gerado com as novas versões do WordPress e WooCommerce.

Para resolver o problema, foi adicionado uma verificação no início da função **calculate_shipping**, onde se o CEP estiver vazio, sai da função.

### Evidências

#### ❌ Antes

![evidencia-antes](https://user-images.githubusercontent.com/17624695/85429562-486a6000-b555-11ea-8cfb-e23b931bf11d.gif)

#### ✔ Depois

![evidencia-depois](https://user-images.githubusercontent.com/17624695/85429593-55874f00-b555-11ea-9ac2-65646a7cbd3d.gif)
